### PR TITLE
prototype for astro db

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,39 @@ const sqlFTS = fts5Table({
 // render actual sql schema to a string
 const sql = sqlFTS();
 ```
+
+### Astro DB
+
+FTS5 sql can be generated from an Astro DB definition, some slight modification to your `db/config.ts` is required to get things to work nicely.
+
+The main changes are to assign a local `TableConfig` variable for your `defineDb` configuration object instead if passing it inline.
+
+```ts
+import { column, defineDb, defineTable } from "astro:db";
+
+const Comment = defineTable({
+  columns: {
+    author: column.text(),
+    body: column.text(),
+  },
+});
+
+// This step is important, otherwise types for fts5TableFromAstroDb don't seem to play nicely
+const TableConfig = {
+  tables: { Comment },
+}
+
+export default defineDb(TableConfig);
+```
+
+We can then in a separate file use `fts5TableFromAstroDb` with type safety to configure a SQL generating method for FTS5 DDL.
+
+```ts
+import { fts5TableFromAstroDb } from "sqlite-fts-util";
+
+const generateSql = fts5TableFromAstroDb(TableConfig, {
+  table: "Comment",
+  idColumn: "id",
+  columns: ["author", "body"]
+});
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqlite-fts-util",
-  "version": "1.0.3",
+  "version": "1.0.5",
   "description": "utility function to help generate SQLite fts5 schema",
   "type": "module",
   "scripts": {
@@ -11,7 +11,11 @@
     "format": "prettier --write \"{src,apps,libs,tests,bin}/**/*.{ts,mjs}\"",
     "lint": "eslint \"{src,apps,libs,tests,bin}/**/*.{ts,mjs}\" --fix --max-warnings 0"
   },
-  "keywords": ["SQLite", "fts5", "turso"],
+  "keywords": [
+    "SQLite",
+    "fts5",
+    "turso"
+  ],
   "author": "JayJamieson",
   "license": "MIT",
   "repository": {
@@ -20,7 +24,12 @@
   "exports": "./dist/index.js",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
-  "files": ["dist", "README.md", "LICENCE", "package.json"],
+  "files": [
+    "dist",
+    "README.md",
+    "LICENCE",
+    "package.json"
+  ],
   "devDependencies": {
     "@types/node": "^20.14.2",
     "@typescript-eslint/eslint-plugin": "^7.12.0",


### PR DESCRIPTION
This is a work in progress. The idea is to be able to use astro db configuration and infer the tables available and the tables columns to generate SQL for a fts5 table.

For this to work to work the `db/config.ts` needs re-arrangement to make types play nicely

```ts
import { column, defineDb, defineTable } from "astro:db";

const Comment = defineTable({
  columns: {
    author: column.text(),
    body: column.text(),
  },
});

const Tables = { Comment };
const TableConfig = {
  tables: Tables,
}

// even though `tables` property is optional this still works?
export default defineDb(TableConfig);
```

With the above I have defined a function that accepts the general shape of `TableConfig` variable and correctly infers what tables can be referenced and table columns for the config parameter of `fts5TableFromAstroDb`.

For example

```ts
fts5TableFromAstroDb(
  { tables: { foo: { columns: { column1: {}, column2: {} } } } },
  {
    table: "foo", // only accepted property is "test"
    columns: ["column1", "column2"], // only accepted column is "column1". anything else would show type error
    idColumn: "id", // still need to figure this part out
  },
);
```

Producing the following sql output

```sql
CREATE VIRTUAL TABLE foo_fts USING fts5(
  column1,
  column2,
  content='foo',
  content_rowid='id'
);
/*--*/
CREATE TRIGGER foo_ai AFTER INSERT ON foo
BEGIN
  INSERT INTO foo_fts (rowid, column1, column2)
  VALUES (new.id, new.column1, new.column2);
END;
/*--*/
CREATE TRIGGER foo_ad AFTER DELETE ON foo
BEGIN
  INSERT INTO foo_fts (foo_fts, rowid, column1, column2)
  VALUES ('delete', old.id, old.column1, old.column2);
END;
/*--*/
CREATE TRIGGER foo_au AFTER UPDATE ON foo
BEGIN
  INSERT INTO foo_fts (foo_fts, rowid, column1, column2)
  VALUES ('delete', old.id, old.column1, old.column2);

  INSERT INTO foo_fts (rowid, column1, column2)
  VALUES (new.id, new.column1, new.column2);
END;
```