### PR TITLE
added additional configuration for tokenizer and prefix indexes

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -2,17 +2,21 @@ import { expect, test } from "vitest";
 import fts5Table from "./index.js";
 
 test("table and columns are required", () => {
-  expect(() => fts5Table({ table: "foo", idColumn: "", columns: [] })).toThrowError(
-    "Table or columns are empty, please provide them",
-  );
+  expect(() =>
+    fts5Table({ table: "foo", idColumn: "", columns: [] }),
+  ).toThrowError("Table or columns are empty, please provide them");
 
-  expect(() => fts5Table({ table: "", idColumn: "", columns: ["foo"] })).toThrowError(
-    "Table or columns are empty, please provide them",
-  );
+  expect(() =>
+    fts5Table({ table: "", idColumn: "", columns: ["foo"] }),
+  ).toThrowError("Table or columns are empty, please provide them");
 });
 
 test("resulting sql can be split on /*--*/", () => {
-  const config = { table: "foo", idColumn: "", columns: ["column1", "column2"] };
+  const config = {
+    table: "foo",
+    idColumn: "",
+    columns: ["column1", "column2"],
+  };
 
   const generateFTS = fts5Table(config);
 
@@ -23,7 +27,11 @@ test("resulting sql can be split on /*--*/", () => {
 });
 
 test("fts5Table can generate successfully", () => {
-  const config = { table: "foo", idColumn: "id", columns: ["column1", "column2"] };
+  const config = {
+    table: "foo",
+    idColumn: "id",
+    columns: ["column1", "column2"],
+  };
 
   const generateFTS = fts5Table(config);
 
@@ -32,6 +40,140 @@ test("fts5Table can generate successfully", () => {
   const expected = `CREATE VIRTUAL TABLE foo_fts USING fts5(
   column1,
   column2,
+  content='foo',
+  content_rowid='id'
+);
+/*--*/
+CREATE TRIGGER foo_ai AFTER INSERT ON foo
+BEGIN
+  INSERT INTO foo_fts (rowid, column1, column2)
+  VALUES (new.id, new.column1, new.column2);
+END;
+/*--*/
+CREATE TRIGGER foo_ad AFTER DELETE ON foo
+BEGIN
+  INSERT INTO foo_fts (foo_fts, rowid, column1, column2)
+  VALUES ('delete', old.id, old.column1, old.column2);
+END;
+/*--*/
+CREATE TRIGGER foo_au AFTER UPDATE ON foo
+BEGIN
+  INSERT INTO foo_fts (foo_fts, rowid, column1, column2)
+  VALUES ('delete', old.id, old.column1, old.column2);
+
+  INSERT INTO foo_fts (rowid, column1, column2)
+  VALUES (new.id, new.column1, new.column2);
+END;`;
+
+  expect(sql).toBe(expected);
+});
+
+test("fts5Table can conditionally add prefix index setting", () => {
+  const config = {
+    table: "foo",
+    idColumn: "id",
+    columns: ["column1", "column2"],
+    prefix: [2, 3],
+  };
+
+  const generateFTS = fts5Table(config);
+
+  const sql = generateFTS();
+
+  const expected = `CREATE VIRTUAL TABLE foo_fts USING fts5(
+  column1,
+  column2,
+  prefix='2 3',
+  content='foo',
+  content_rowid='id'
+);
+/*--*/
+CREATE TRIGGER foo_ai AFTER INSERT ON foo
+BEGIN
+  INSERT INTO foo_fts (rowid, column1, column2)
+  VALUES (new.id, new.column1, new.column2);
+END;
+/*--*/
+CREATE TRIGGER foo_ad AFTER DELETE ON foo
+BEGIN
+  INSERT INTO foo_fts (foo_fts, rowid, column1, column2)
+  VALUES ('delete', old.id, old.column1, old.column2);
+END;
+/*--*/
+CREATE TRIGGER foo_au AFTER UPDATE ON foo
+BEGIN
+  INSERT INTO foo_fts (foo_fts, rowid, column1, column2)
+  VALUES ('delete', old.id, old.column1, old.column2);
+
+  INSERT INTO foo_fts (rowid, column1, column2)
+  VALUES (new.id, new.column1, new.column2);
+END;`;
+
+  expect(sql).toBe(expected);
+});
+
+test("fts5Table can conditionally add tokenize setting", () => {
+  const config = {
+    table: "foo",
+    idColumn: "id",
+    columns: ["column1", "column2"],
+    tokenize: "porter ascii",
+  };
+
+  const generateFTS = fts5Table(config);
+
+  const sql = generateFTS();
+
+  const expected = `CREATE VIRTUAL TABLE foo_fts USING fts5(
+  column1,
+  column2,
+  tokenize='porter ascii',
+  content='foo',
+  content_rowid='id'
+);
+/*--*/
+CREATE TRIGGER foo_ai AFTER INSERT ON foo
+BEGIN
+  INSERT INTO foo_fts (rowid, column1, column2)
+  VALUES (new.id, new.column1, new.column2);
+END;
+/*--*/
+CREATE TRIGGER foo_ad AFTER DELETE ON foo
+BEGIN
+  INSERT INTO foo_fts (foo_fts, rowid, column1, column2)
+  VALUES ('delete', old.id, old.column1, old.column2);
+END;
+/*--*/
+CREATE TRIGGER foo_au AFTER UPDATE ON foo
+BEGIN
+  INSERT INTO foo_fts (foo_fts, rowid, column1, column2)
+  VALUES ('delete', old.id, old.column1, old.column2);
+
+  INSERT INTO foo_fts (rowid, column1, column2)
+  VALUES (new.id, new.column1, new.column2);
+END;`;
+
+  expect(sql).toBe(expected);
+});
+
+test("fts5Table can conditionally add tokenize and prefix setting", () => {
+  const config = {
+    table: "foo",
+    idColumn: "id",
+    columns: ["column1", "column2"],
+    prefix: [2, 3],
+    tokenize: "porter ascii",
+  };
+
+  const generateFTS = fts5Table(config);
+
+  const sql = generateFTS();
+
+  const expected = `CREATE VIRTUAL TABLE foo_fts USING fts5(
+  column1,
+  column2,
+  prefix='2 3',
+  tokenize='porter ascii',
   content='foo',
   content_rowid='id'
 );

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -11,6 +11,41 @@ test("table and columns are required", () => {
   ).toThrowError("Table or columns are empty, please provide them");
 });
 
+test("invalid tokenizers throws", () => {
+  const config = {
+    table: "foo",
+    idColumn: "id",
+    columns: ["column1", "column2"],
+  };
+
+  expect(() =>
+    fts5Table({
+      ...config,
+      tokenize: {
+        tokenizer: "invalid1",
+      },
+    }),
+  ).toThrowError("Invalid tokenizer: invalid");
+
+  expect(() =>
+    fts5Table({
+      ...config,
+      tokenize: {
+        tokenizer: "Porter",
+      },
+    }),
+  ).toThrowError("Invalid tokenizer: Porter");
+
+  expect(() =>
+    fts5Table({
+      ...config,
+      tokenize: {
+        tokenizer: "porter porter",
+      },
+    }),
+  ).toThrowError("Invalid tokenizer: porter porter");
+});
+
 test("resulting sql can be split on /*--*/", () => {
   const config = {
     table: "foo",
@@ -117,7 +152,10 @@ test("fts5Table can conditionally add tokenize setting", () => {
     table: "foo",
     idColumn: "id",
     columns: ["column1", "column2"],
-    tokenize: "porter ascii",
+    tokenize: {
+      tokenizer: "porter unicode61",
+      options: "remove_diacritics 1 tokenchars '-_'",
+    },
   };
 
   const generateFTS = fts5Table(config);
@@ -127,7 +165,7 @@ test("fts5Table can conditionally add tokenize setting", () => {
   const expected = `CREATE VIRTUAL TABLE foo_fts USING fts5(
   column1,
   column2,
-  tokenize='porter ascii',
+  tokenize="porter unicode61 remove_diacritics 1 tokenchars '-_'",
   content='foo',
   content_rowid='id'
 );
@@ -162,7 +200,9 @@ test("fts5Table can conditionally add tokenize and prefix setting", () => {
     idColumn: "id",
     columns: ["column1", "column2"],
     prefix: [2, 3],
-    tokenize: "porter ascii",
+    tokenize: {
+      tokenizer: "porter ascii",
+    },
   };
 
   const generateFTS = fts5Table(config);
@@ -173,7 +213,7 @@ test("fts5Table can conditionally add tokenize and prefix setting", () => {
   column1,
   column2,
   prefix='2 3',
-  tokenize='porter ascii',
+  tokenize="porter ascii",
   content='foo',
   content_rowid='id'
 );

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,23 @@ export type FTSConfig = {
    */
   idColumn?: string;
   columns: string[];
+
+  /**
+   * Tokenizer setting
+   * See {@link https://sqlite.org/fts5.html#tokenizers}
+   * @example tokenize: "porter ascii"
+   *
+   * @example tokenize: "unicode61 remove_diacritics 0 tokenchars '-_'"
+   */
+  tokenize?: string;
+
+  /**
+   * Configure an additional prefix index of n size
+   * @example
+   * prefix: [2, 3] // will create a 2 char prefix index and 3 char prefix index
+   *
+   */
+  prefix?: number[];
 };
 
 /**
@@ -23,6 +40,12 @@ const virtualTable = `CREATE VIRTUAL TABLE {{table}}_fts USING fts5(
   {{#each columns}}
   {{this}},
   {{/each}}
+  {{#if prefix}}
+  prefix='{{prefix}}',
+  {{/if}}
+  {{#if tokenize}}
+  tokenize='{{tokenize}}',
+  {{/if}}
   content='{{table}}',
   content_rowid='{{idColumn}}'
 );
@@ -75,6 +98,12 @@ export default function fts5Table(config: FTSConfig): () => string {
   const idColumn = config.idColumn || "id";
   config.idColumn = idColumn;
 
+  let prefix = "";
+
+  if (config.prefix !== undefined) {
+    prefix = config.prefix.join(" ");
+  }
+
   if (table.length === 0 || columns.length === 0) {
     throw new Error("Table or columns are empty, please provide them");
   }
@@ -83,7 +112,10 @@ export default function fts5Table(config: FTSConfig): () => string {
   const template = Handlebars.compile(virtualTable + triggers);
 
   return () => {
-    return template(config);
+    return template({
+      ...config,
+      prefix,
+    });
   };
 }
 


### PR DESCRIPTION
Adds support for injecting `tokenize` and `prefix` FTS5 index creation settings. Basic type safety is offered, a more complex type could be defined for tokenize options but this seems overkill beyond the validation in place.

New API provides two optional configuration properties
```ts
const sqlFTS = fts5Table({
  table: "recipes",
  columns: ["title", "directions"],
  prefix: [2, 3], // new 
  tokenize: "porter ascii", // new
});
```